### PR TITLE
Remove dots in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,11 +2,11 @@
 /.bundle
 /vendor/bundle
 
-# SQLite database.
+# SQLite database
 /db/*.sqlite3
 /db/*.sqlite3-journal
 
-# Logfiles/Tempfiles.
+# Logfiles/Tempfiles
 /log/*
 /tmp/*
 !/log/.keep


### PR DESCRIPTION
This is a personal stylistic decision that we keep consistent in our
gitignore.