### PR TITLE
Fix/Add Error Handling to Task Creation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,5 +17,8 @@ Style/FrozenStringLiteralComment:
 Style/Documentation:
   Enabled: false
 
+Style/AndOr:
+  Enabled: false
+
 Metrics/LineLength:
   Enabled: false

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,11 +1,8 @@
 class TasksController < ApplicationController
   def create
     @task = Task.create(task_params)
-    if @task.save
-      render json: @task, status: 201
-    else
-      render json: errors, status: 422
-    end
+    render json: @task, status: 201 and return if @task.save
+    render json: errors, status: 422
   end
 
   def index
@@ -14,11 +11,8 @@ class TasksController < ApplicationController
 
   def update
     @task = Task.find(params[:id])
-    if @task.update_attributes(task_params)
-      render json: @task
-    else
-      render json: errors, status: 422
-    end
+    render json: @task and return if update_task!
+    render json: errors, status: 422
   end
 
   private
@@ -29,5 +23,9 @@ class TasksController < ApplicationController
 
   def errors
     { errors: @task.errors.full_messages }
+  end
+
+  def update_task!
+    @task.update_attributes(task_params)
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,10 +1,10 @@
 class TasksController < ApplicationController
   def create
-    task = Task.create(task_params)
-    if task.save
-      render json: task, status: 201
+    @task = Task.create(task_params)
+    if @task.save
+      render json: @task, status: 201
     else
-      render json: { errors: task.errors.full_messages }, status: 422
+      render json: errors, status: 422
     end
   end
 
@@ -13,11 +13,11 @@ class TasksController < ApplicationController
   end
 
   def update
-    task = Task.find(params[:id])
-    if task.update_attributes(task_params)
-      render json: task
+    @task = Task.find(params[:id])
+    if @task.update_attributes(task_params)
+      render json: @task
     else
-      render json: { errors: task.errors.full_messages }, status: 422
+      render json: errors, status: 422
     end
   end
 
@@ -25,5 +25,9 @@ class TasksController < ApplicationController
 
   def task_params
     params.permit(:name)
+  end
+
+  def errors
+    { errors: @task.errors.full_messages }
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,7 +1,11 @@
 class TasksController < ApplicationController
   def create
     task = Task.create(task_params)
-    render json: task, status: 201
+    if task.save
+      render json: task, status: 201
+    else
+      render json: { errors: task.errors.full_messages }, status: 422
+    end
   end
 
   def index

--- a/spec/requests/task_request_spec.rb
+++ b/spec/requests/task_request_spec.rb
@@ -16,7 +16,19 @@ describe 'Tasks API', type: :request do
     end
 
     it 'returns the correct status code' do
-      expect(response).to have_http_status(:created)
+      expect(response).to have_http_status :created
+    end
+
+    context 'when task creation fails' do
+      let(:params) { { name: nil } }
+
+      it 'returns an error' do
+        expect(body).to include('errors' => ["Name can't be blank"])
+      end
+
+      it 'returns the correct status code' do
+        expect(response).to have_http_status 422
+      end
     end
   end
 
@@ -50,7 +62,7 @@ describe 'Tasks API', type: :request do
     end
 
     it 'returns the correct status code' do
-      expect(response).to have_http_status(200)
+      expect(response).to have_http_status 200
     end
 
     context 'when the task update fails' do
@@ -61,7 +73,7 @@ describe 'Tasks API', type: :request do
       end
 
       it 'returns the correct status code' do
-        expect(response).to have_http_status(422)
+        expect(response).to have_http_status 422
       end
     end
   end

--- a/spec/requests/task_request_spec.rb
+++ b/spec/requests/task_request_spec.rb
@@ -2,11 +2,10 @@ require 'rails_helper'
 
 describe 'Tasks API', type: :request do
   let(:body) { JSON.parse(response.body) }
+  let(:params) { { name: 'SomeName' } }
 
   describe 'POST #create' do
-    before do
-      post '/tasks', params: { name: 'SomeName' }
-    end
+    before { post '/tasks', params: params }
 
     it 'creates a new task' do
       expect(Task.last.name).to eq 'SomeName'
@@ -39,11 +38,8 @@ describe 'Tasks API', type: :request do
 
   describe 'PATCH #update' do
     let!(:task) { create :task }
-    let(:params) { { name: 'SomeName' } }
 
-    before do
-      patch '/tasks/1', params: params
-    end
+    before { patch '/tasks/1', params: params }
 
     it 'can update task names' do
       expect(task.reload.name).to eq 'SomeName'


### PR DESCRIPTION
### What's New?
We were returning 200 when task creation failed. We solve that issue by sending an error instead.
