### PR TITLE
Fix/Uniformize Errors

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,11 @@
 class ApplicationController < ActionController::API
+  rescue_from ActiveRecord::RecordNotFound, with: :render_404
+
+  def render_404(error)
+    render json: { error: { message: error.message } }, status: :not_found
+  end
+
+  def render_422(record)
+    render json: { error: { message: record.errors.full_messages.first } }, status: 422
+  end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -44,6 +44,6 @@ class TasksController < ApplicationController
   end
 
   def render_422
-    render json: { errors: @task.errors.full_messages }, status: 422
+    render json: { error: { message: @task.errors.full_messages.first } }, status: 422
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,8 +1,6 @@
 class TasksController < ApplicationController
-  rescue_from ActiveRecord::RecordNotFound, with: :render_404
-
   def create
-    render_422 and return unless create_task!
+    render_422(task) and return unless create_task!
     render json: task, status: 201
   end
 
@@ -11,7 +9,7 @@ class TasksController < ApplicationController
   end
 
   def update
-    render_422 and return unless update_task!
+    render_422(task) and return unless update_task!
     render json: task
   end
 
@@ -37,13 +35,5 @@ class TasksController < ApplicationController
 
   def task
     @task ||= Task.find(params[:id])
-  end
-
-  def render_404(error)
-    render json: { error: { message: error.message } }, status: :not_found
-  end
-
-  def render_422
-    render json: { error: { message: @task.errors.full_messages.first } }, status: 422
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -40,7 +40,7 @@ class TasksController < ApplicationController
   end
 
   def render_404(error)
-    render json: { error: error.message }, status: :not_found
+    render json: { error: { message: error.message } }, status: :not_found
   end
 
   def render_422

--- a/spec/requests/task_request_spec.rb
+++ b/spec/requests/task_request_spec.rb
@@ -4,6 +4,10 @@ describe 'Tasks API', type: :request do
   let(:body) { JSON.parse(response.body) }
   let(:params) { { name: 'SomeName' } }
 
+  let(:not_found_error) do
+    { 'error' => { 'message' => "Couldn't find Task with 'id'=1" } }
+  end
+
   describe 'POST /tasks' do
     before { post '/tasks', params: params }
 
@@ -92,7 +96,7 @@ describe 'Tasks API', type: :request do
       end
 
       it 'returns the correct error' do
-        expect(body).to include('error' => "Couldn't find Task with 'id'=1")
+        expect(body).to include not_found_error
       end
     end
   end
@@ -120,7 +124,7 @@ describe 'Tasks API', type: :request do
       end
 
       it 'returns the correct error' do
-        expect(body).to include('error' => "Couldn't find Task with 'id'=1")
+        expect(body).to include not_found_error
       end
     end
   end

--- a/spec/requests/task_request_spec.rb
+++ b/spec/requests/task_request_spec.rb
@@ -8,6 +8,10 @@ describe 'Tasks API', type: :request do
     { 'error' => { 'message' => "Couldn't find Task with 'id'=1" } }
   end
 
+  let(:missing_name_error) do
+    { 'error' => { 'message' => "Name can't be blank" } }
+  end
+
   describe 'POST /tasks' do
     before { post '/tasks', params: params }
 
@@ -27,7 +31,7 @@ describe 'Tasks API', type: :request do
       let(:params) { { name: nil } }
 
       it 'returns an error' do
-        expect(body).to include('errors' => ["Name can't be blank"])
+        expect(body).to include missing_name_error
       end
 
       it 'returns the correct status code' do
@@ -80,7 +84,7 @@ describe 'Tasks API', type: :request do
       before { update }
 
       it 'returns an error' do
-        expect(body).to include('errors' => ["Name can't be blank"])
+        expect(body).to include missing_name_error
       end
 
       it 'returns the correct status code' do


### PR DESCRIPTION
Issue: https://github.com/KarlHarnois/task_api/issues/20
We were returning errors with different json structure to our api users. We uniformize the error schema:
```json
{
  "error": {
    "message": "Some error message."
  }
}
```