### PR TITLE
Record Task Completion

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -30,7 +30,7 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.permit(:name)
+    params.permit(:name, :completed_at)
   end
 
   def task

--- a/db/migrate/20180212014150_add_completed_at_to_tasks.rb
+++ b/db/migrate/20180212014150_add_completed_at_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddCompletedAtToTasks < ActiveRecord::Migration[5.1]
+  def change
+    add_column :tasks, :completed_at, :datetime
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180131153803) do
+ActiveRecord::Schema.define(version: 20180212014150) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 20180131153803) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "completed_at"
   end
 
 end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -5,6 +5,10 @@ describe Task, type: :model do
     expect(FactoryBot.create(:task)).to be_valid
   end
 
+  it 'has a completion date' do
+    expect(Task.column_names).to include 'completed_at'
+  end
+
   describe '#save' do
     context 'when task name is nil' do
       before { subject.name = nil }

--- a/spec/requests/task_request_spec.rb
+++ b/spec/requests/task_request_spec.rb
@@ -2,7 +2,13 @@ require 'rails_helper'
 
 describe 'Tasks API', type: :request do
   let(:body) { JSON.parse(response.body) }
-  let(:params) { { name: 'SomeName' } }
+
+  let(:params) do
+    {
+      name: 'SomeName',
+      completed_at: '19 August 1993'
+    }
+  end
 
   let(:headers) do
     { 'Authorization' => "Basic #{Base64.strict_encode64('SomeName:SomePassword')}" }
@@ -62,10 +68,14 @@ describe 'Tasks API', type: :request do
     context 'when the task update succeed' do
       let!(:task) { create :task, id: 1 }
 
+      let(:expected_attributes) do
+        { name: 'SomeName', completed_at: '1993-08-19'.to_datetime }
+      end
+
       before { patch_task }
 
-      it 'can update task names' do
-        expect(task.reload.name).to eq 'SomeName'
+      it "can update the task's attributes" do
+        expect(task.reload).to have_attributes(expected_attributes)
       end
 
       it 'returns the updated task' do


### PR DESCRIPTION
We add the `Task.completed_at` DateTime attribute to handle when a task is completed. We didn't go with a simple `done` boolean flag since we wanted to record when a task was completed, for future graphs or stats

Issue: https://github.com/KarlHarnois/task_api/issues/7