### PR TITLE
Add task and id as required params

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -32,7 +32,7 @@ class TasksController < ApplicationController
   end
 
   def task_params
-    params.permit(:name, :completed_at)
+    params.require(:task).permit(:id, :name, :completed_at)
   end
 
   def task

--- a/spec/requests/task_request_spec.rb
+++ b/spec/requests/task_request_spec.rb
@@ -5,8 +5,10 @@ describe 'Tasks API', type: :request do
 
   let(:params) do
     {
-      name: 'SomeName',
-      completed_at: '19 August 1993'
+      task: {
+        name: 'SomeName',
+        completed_at: '19 August 1993'
+      }
     }
   end
 
@@ -34,7 +36,7 @@ describe 'Tasks API', type: :request do
     end
 
     context 'when task creation fails' do
-      let(:params) { { name: nil } }
+      let(:params) { { task: { name: nil } } }
 
       it 'returns an error' do
         expect(body).to include missing_name_error
@@ -109,7 +111,7 @@ describe 'Tasks API', type: :request do
 
     context 'when the task update fails' do
       let!(:task) { create :task, id: 1 }
-      let(:params) { { name: nil } }
+      let(:params) { { task: { name: nil } } }
 
       before { patch_task }
 


### PR DESCRIPTION
We had an issue with our production instances where patch requests were
rejected because of the missing `id` param so we add it. We took that
opportunity to address another warning and add the missing `task` param
as required.